### PR TITLE
automatically generating unique myid per zookeeper instance

### DIFF
--- a/inventories/poundpay
+++ b/inventories/poundpay
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
-import os
-
+import os, json
 from confu import aws, ansible
+from boto import ec2, exception
 
 
 region = os.environ.get('AWS_REGION', 'us-east-1')
-aws.cxn.activate(profile_name='poundpay', default_region=region)
+aws_access_key_id = os.environ.get('AWS_ACCESS_KEY_ID')
+aws_secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
 
+aws.cxn.activate(profile_name='poundpay', default_region=region)
 inventory = ansible.AWSRemoteInventory(
     instances=(
         aws.instances()
@@ -22,5 +24,24 @@ inventory = ansible.AWSRemoteInventory(
     ],
 )
 
+def get_instance_indices(region, aws_access_key_id, aws_secret_access_key):
+#    import ipdb; ipdb.set_trace()
+    conn = ec2.connect_to_region(region,aws_access_key_id = aws_access_key_id, aws_secret_access_key = aws_secret_access_key)
+    rinstances = conn.get_all_instances()
+    output = {}
+    id = 1
+    for rinstance in rinstances:
+        iinstance = rinstance.instances[0]
+        try:
+            if iinstance.tags['confu:infra-silo'] == 'zookeeper' and iinstance.state == 'running':
+                output[iinstance.private_ip_address.encode()] = {'myid': id }
+                id = id + 1
+        except KeyError:
+            pass
+    return output
+
 if __name__ == '__main__':
-    inventory.cli()
+    result = inventory.all()
+    result['_meta']['hostvars'] = dict(get_instance_indices(region, aws_access_key_id, aws_secret_access_key))
+    print json.dumps(result, indent=4, sort_keys=True)
+


### PR DESCRIPTION
Adding some logic to inventories/poundpay  to automatically generate uniq myid variable per zookeeper instances as a host variable in dynamically generated inventory.
